### PR TITLE
fix(style): fix virtual keyboard height error

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -84,6 +84,6 @@ math-field::part(content) {
 }
 
 .virt-keyboard > div {
-  height: 40vh;
+  height: var(--_keyboard-height);
   width: 100vw;
 }


### PR DESCRIPTION
Use CSS varaible `--_keyboard-height` instead of fixed value as keyboard height, which is dynamic element style and managed by Mathlive JS

fixes #10, fixes #9 